### PR TITLE
Specify which command entrypoint.sh should run

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - ${PWD}/data:/root/.bitcoin:ro
       - ${PWD}/data:/home/bitcoin/.bitcoin
     command:
+      bitcoind
       -server
       -testnet=${TESTNET}
       -rpcuser=${RPCUSER}


### PR DESCRIPTION
The bitcoin container's entrypoint.sh accepts one of three commands: `bitcoind`, `bitcoin-cli` or `bitcoin-tx`. 

Right now it doesn't seem like we're passing any of these. We're just passing flags: `-server -testnet=... -rpcuser=...`

None of the RPC worked before this one line change, afterwards it did.