### PR TITLE
UI for mining blocks in regtest

### DIFF
--- a/services/admin_website/app/app/templates/admin/bitcoind_home.html
+++ b/services/admin_website/app/app/templates/admin/bitcoind_home.html
@@ -1,6 +1,7 @@
 {% extends 'admin/master.html' %}
 
 {% import 'definition_list_macro.html' as data %}
+{% from "form_macros.html" import render_field %}
 
 {% block body %}
     <script type="text/javascript" charset="utf-8">
@@ -25,6 +26,28 @@
     </script>
 
     <div class="container">
+
+        {% if network == 'regtest' %}
+        <div class="row">
+            <div class="col-md-1"></div>
+            <div class="col-md-10">
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <h3 class="panel-title">Regtest dials</h3>
+                    </div>
+                    <div class="panel-body">
+                        <dl class="dl-horizontal">
+                            <form method=post>
+                                {{ render_field(mine_blocks_form.num_blocks) }}
+                                <button class="btn btn-primary" type="submit" value="Mine">Mine</button>
+                            </form>
+                        </dl>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-1"></div>
+        </div>
+        {% endif %}
 
         <div class="row">
             <div class="col-md-1">

--- a/services/admin_website/app/app/templates/form_macros.html
+++ b/services/admin_website/app/app/templates/form_macros.html
@@ -1,0 +1,12 @@
+{% macro render_field(field) %}
+  <dt>{{ field.label }}
+  <dd>{{ field(**kwargs)|safe }}
+  {% if field.errors %}
+    <ul class=errors>
+    {% for error in field.errors %}
+      <li>{{ error }}</li>
+    {% endfor %}
+    </ul>
+  {% endif %}
+  </dd>
+{% endmacro %}


### PR DESCRIPTION
`bitcoin-cli` has a `generate nBlocks` command when running `bitcoind` in regtest mode.

This UI just exercises that call.

This UI is only visible when the `$NETWORK=regtest` is set. 